### PR TITLE
Compatible with AGP 8.0+ and Android 12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.rex.android_usb_printer'
+    }
+
     compileSdkVersion 31
 
     compileOptions {

--- a/android/src/main/kotlin/com/rex/android_usb_printer/tools/UsbDeviceHelper.kt
+++ b/android/src/main/kotlin/com/rex/android_usb_printer/tools/UsbDeviceHelper.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.hardware.usb.*
+import android.os.Build
 import io.flutter.Log
 
 /**
@@ -27,11 +28,15 @@ class UsbDeviceHelper private constructor() {
 
     fun init(context: Context) {
         this.mContext = context
+        var flags = 0
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            flags = flags or PendingIntent.FLAG_IMMUTABLE
+        }
         mPermissionIntent = PendingIntent.getBroadcast(
             context,
             0,
             Intent(UsbDeviceReceiver.Config.ACTION_USB_PERMISSION),
-            0
+            flags
         )
         usbManager = context.applicationContext.getSystemService(Context.USB_SERVICE) as UsbManager
     }


### PR DESCRIPTION
Fixed 2 issues:
1. Namespace not specified. Specify a namespace in the module's build file. (Android Gradle Plugin 8.0.0 required namespace)

2. Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent. (cause `UsbDeviceHelper.init` failed #1 )